### PR TITLE
use qemu when building not on x86_64 for aml_encrypt

### DIFF
--- a/axg.inc
+++ b/axg.inc
@@ -10,6 +10,11 @@ else
 	BL33_ARGS :=--compress lz4
 endif
 
+UNAME_M := $(shell uname -m)
+ifneq ($(UNAME_M),x86_64)
+	QEMU =  qemu-x86_64
+endif
+
 AML_ENCRYPT ?= aml_encrypt_axg
 
 .PHONY: clean distclean
@@ -58,19 +63,19 @@ ${O}/u-boot.bin: ${TMP}/bl2.n.bin.sig ${TMP}/bl30_new.bin.enc ${TMP}/bl31.img.en
 	dd if=${O}/u-boot.bin of=${O}/u-boot.bin.usb.bl2 bs=49152 count=1
 else
 ${TMP}/bl30_new.bin.enc: ${TMP}/bl30_new.bin
-	./${AML_ENCRYPT} --bl3sig --input ${TMP}/bl30_new.bin --output ${TMP}/bl30_new.bin.enc  --level 3 --type bl30
+	${QEMU} ./${AML_ENCRYPT} --bl3sig --input ${TMP}/bl30_new.bin --output ${TMP}/bl30_new.bin.enc  --level 3 --type bl30
 
 ${TMP}/bl31.img.enc: bl31.img
-	./${AML_ENCRYPT} --bl3sig --input bl31.img --output ${TMP}/bl31.img.enc --level 3 --type bl31
+	${QEMU} ./${AML_ENCRYPT} --bl3sig --input bl31.img --output ${TMP}/bl31.img.enc --level 3 --type bl31
 
 ${TMP}/bl33.bin.enc: ${BL33}
-	./${AML_ENCRYPT} --bl3sig --input ${BL33} --output ${TMP}/bl33.bin.enc --level 3 --type bl33 ${BL33_ARGS}
+	${QEMU} ./${AML_ENCRYPT} --bl3sig --input ${BL33} --output ${TMP}/bl33.bin.enc --level 3 --type bl33 ${BL33_ARGS}
 
 ${TMP}/bl2.n.bin.sig: ${TMP}/bl2_new.bin
-	./${AML_ENCRYPT} --bl2sig --input ${TMP}/bl2_new.bin --output ${TMP}/bl2.n.bin.sig
+	${QEMU} ./${AML_ENCRYPT} --bl2sig --input ${TMP}/bl2_new.bin --output ${TMP}/bl2.n.bin.sig
 
 ${O}/u-boot.bin: ${TMP}/bl2.n.bin.sig ${TMP}/bl30_new.bin.enc ${TMP}/bl31.img.enc ${TMP}/bl33.bin.enc
-	./${AML_ENCRYPT} --bootmk --output ${O}/u-boot.bin --level v3 \
+	${QEMU} ./${AML_ENCRYPT} --bootmk --output ${O}/u-boot.bin --level v3 \
 	               --bl2 ${TMP}/bl2.n.bin.sig --bl30 ${TMP}/bl30_new.bin.enc \
 		       --bl31 ${TMP}/bl31.img.enc --bl33 ${TMP}/bl33.bin.enc \
 		       --level 3

--- a/g12a.inc
+++ b/g12a.inc
@@ -9,6 +9,11 @@ else
 	BL33_ARGS :=--compress lz4
 endif
 
+UNAME_M := $(shell uname -m)
+ifneq ($(UNAME_M),x86_64)
+	QEMU =  qemu-x86_64
+endif
+
 AML_ENCRYPT ?= aml_encrypt_g12a
 
 .PHONY: clean distclean
@@ -69,30 +74,30 @@ ${O}/u-boot.bin: ${TMP}/bl2.n.bin.sig ${TMP}/bl30_new.bin.enc ${TMP}/bl31.img.en
 	fi
 else
 ${TMP}/bl30_new.bin.g12a.enc: ${TMP}/bl30_new.bin
-	./${AML_ENCRYPT} --bl30sig --input ${TMP}/bl30_new.bin --output ${TMP}/bl30_new.bin.g12a.enc --level v3
+	${QEMU} ./${AML_ENCRYPT} --bl30sig --input ${TMP}/bl30_new.bin --output ${TMP}/bl30_new.bin.g12a.enc --level v3
 
 ${TMP}/bl30_new.bin.enc: ${TMP}/bl30_new.bin.g12a.enc
-	./${AML_ENCRYPT} --bl3sig --input ${TMP}/bl30_new.bin.g12a.enc --output ${TMP}/bl30_new.bin.enc --level v3 --type bl30
+	${QEMU} ./${AML_ENCRYPT} --bl3sig --input ${TMP}/bl30_new.bin.g12a.enc --output ${TMP}/bl30_new.bin.enc --level v3 --type bl30
 
 ${TMP}/bl31.img.enc: bl31.img
-	./${AML_ENCRYPT} --bl3sig --input bl31.img --output ${TMP}/bl31.img.enc --level v3 --type bl31
+	${QEMU} ./${AML_ENCRYPT} --bl3sig --input bl31.img --output ${TMP}/bl31.img.enc --level v3 --type bl31
 
 ${TMP}/bl33.bin.enc: ${BL33}
-	./${AML_ENCRYPT} --bl3sig --input ${BL33} --output ${TMP}/bl33.bin.enc --level v3 --type bl33 ${BL33_ARGS}
+	${QEMU} ./${AML_ENCRYPT} --bl3sig --input ${BL33} --output ${TMP}/bl33.bin.enc --level v3 --type bl33 ${BL33_ARGS}
 
 ${TMP}/bl2.n.bin.sig: ${TMP}/bl2_new.bin
-	./${AML_ENCRYPT} --bl2sig --input ${TMP}/bl2_new.bin --output ${TMP}/bl2.n.bin.sig
+	${QEMU} ./${AML_ENCRYPT} --bl2sig --input ${TMP}/bl2_new.bin --output ${TMP}/bl2.n.bin.sig
 
 ${O}/u-boot.bin: ${TMP}/bl2.n.bin.sig ${TMP}/bl30_new.bin.enc ${TMP}/bl31.img.enc ${TMP}/bl33.bin.enc
 	if [ -e lpddr3_1d.fw ] ; then \
-		./${AML_ENCRYPT} --bootmk --output ${O}/u-boot.bin --level v3 \
+		${QEMU} ./${AML_ENCRYPT} --bootmk --output ${O}/u-boot.bin --level v3 \
 			       --bl2 ${TMP}/bl2.n.bin.sig --bl30 ${TMP}/bl30_new.bin.enc \
 			       --bl31 ${TMP}/bl31.img.enc --bl33 ${TMP}/bl33.bin.enc \
 			       --ddrfw1 ddr4_1d.fw --ddrfw2 ddr4_2d.fw --ddrfw3 ddr3_1d.fw \
 			       --ddrfw4 piei.fw --ddrfw5 lpddr4_1d.fw --ddrfw6 lpddr4_2d.fw \
 			       --ddrfw7 diag_lpddr4.fw --ddrfw8 aml_ddr.fw --ddrfw9 lpddr3_1d.fw ;\
 	else \
-		./${AML_ENCRYPT} --bootmk --output ${O}/u-boot.bin --level v3 \
+		${QEMU} ./${AML_ENCRYPT} --bootmk --output ${O}/u-boot.bin --level v3 \
 			       --bl2 ${TMP}/bl2.n.bin.sig --bl30 ${TMP}/bl30_new.bin.enc \
 			       --bl31 ${TMP}/bl31.img.enc --bl33 ${TMP}/bl33.bin.enc \
 			       --ddrfw1 ddr4_1d.fw --ddrfw2 ddr4_2d.fw --ddrfw3 ddr3_1d.fw \

--- a/gxbb.inc
+++ b/gxbb.inc
@@ -2,6 +2,11 @@ O ?= .
 TMP ?= .
 BL33 ?=
 
+UNAME_M := $(shell uname -m)
+ifneq ($(UNAME_M),x86_64)
+	QEMU =  qemu-x86_64
+endif
+
 .PHONY: clean distclean
 .NOTPARALLEL: ${TMP}/bl30_new.bin ${TMP}/fip.bin ${TMP}/bl2_acs.bin ${TMP}/bl2_new.bin ${TMP}/boot_new.bin ${O}/u-boot.bin
 
@@ -26,7 +31,7 @@ ${TMP}/bl30_new.bin: bl30.bin bl301.bin
 	./blx_fix.sh bl30.bin ${TMP}/zero_tmp ${TMP}/bl30_zero.bin bl301.bin ${TMP}/bl301_zero.bin ${TMP}/bl30_new.bin bl30
 
 ${TMP}/fip.bin: ${TMP}/bl30_new.bin bl31.img ${BL33}
-	./fip_create --bl30 ${TMP}/bl30_new.bin --bl31 bl31.img --bl33 ${BL33} ${TMP}/fip.bin
+	${QEMU} ./fip_create --bl30 ${TMP}/bl30_new.bin --bl31 bl31.img --bl33 ${BL33} ${TMP}/fip.bin
 
 ${TMP}/bl2_acs.bin: bl2.bin acs.bin
 	sed -i 's/\x73\x02\x08\x91/\x1F\x20\x03\xD5/' bl2.bin
@@ -39,11 +44,11 @@ ${TMP}/boot_new.bin: ${TMP}/fip.bin ${TMP}/bl2_new.bin
 	cat ${TMP}/bl2_new.bin ${TMP}/fip.bin > ${TMP}/boot_new.bin
 
 ${O}/u-boot.bin: ${TMP}/boot_new.bin
-	./aml_encrypt_gxb --bootsig --input ${TMP}/boot_new.bin --output ${TMP}/u-boot.bin
+	${QEMU} ./aml_encrypt_gxb --bootsig --input ${TMP}/boot_new.bin --output ${TMP}/u-boot.bin
 	dd if=$(TMP)/u-boot.bin of=$(TMP)/u-boot.bin.gxbb bs=512 conv=fsync
 	dd if=$(TMP)/u-boot.bin of=$(TMP)/u-boot.bin.gxbb bs=512 seek=9 skip=8 count=87 conv=fsync,notrunc
 	dd if=/dev/zero of=$(TMP)/u-boot.bin.gxbb bs=512 seek=8 count=1 conv=fsync,notrunc
 	dd if=bl1.bin.hardkernel of=$(TMP)/u-boot.bin.gxbb bs=512 seek=2 skip=2 count=1 conv=fsync,notrunc
-	./aml_chksum $(TMP)/u-boot.bin.gxbb
+	${QEMU} ./aml_chksum $(TMP)/u-boot.bin.gxbb
 	cp -R ${TMP}/u-boot.bin.gxbb ${O}/u-boot.bin
 	cp -R ${TMP}/u-boot.bin.gxbb ${O}/u-boot.bin.sd.bin

--- a/gxl.inc
+++ b/gxl.inc
@@ -9,6 +9,11 @@ else
 	BL33_ARGS :=--compress lz4
 endif
 
+UNAME_M := $(shell uname -m)
+ifneq ($(UNAME_M),x86_64)
+	QEMU =  qemu-x86_64
+endif
+
 .PHONY: clean distclean
 .NOTPARALLEL: ${TMP}/bl30_new.bin ${TMP}/bl2_acs.bin ${TMP}/bl2_new.bin ${TMP}/bl30_new.bin.enc ${TMP}/bl31.img.enc ${TMP}/bl33.bin.enc ${TMP}/bl2.n.bin.sig ${O}/u-boot.bin
 
@@ -59,19 +64,19 @@ ${O}/u-boot.bin: ${TMP}/bl2.n.bin.sig ${TMP}/bl30_new.bin.enc ${TMP}/bl31.img.en
 	dd if=${O}/u-boot.bin of=${O}/u-boot.bin.usb.bl2 bs=49152 count=1
 else
 ${TMP}/bl30_new.bin.enc: ${TMP}/bl30_new.bin
-	./aml_encrypt_gxl --bl3enc --input ${TMP}/bl30_new.bin --output ${TMP}/bl30_new.bin.enc
+	${QEMU} ./aml_encrypt_gxl --bl3enc --input ${TMP}/bl30_new.bin --output ${TMP}/bl30_new.bin.enc
 
 ${TMP}/bl31.img.enc: bl31.img
-	./aml_encrypt_gxl --bl3enc --input bl31.img --output ${TMP}/bl31.img.enc
+	${QEMU} ./aml_encrypt_gxl --bl3enc --input bl31.img --output ${TMP}/bl31.img.enc
 
 ${TMP}/bl33.bin.enc: ${BL33}
-	./aml_encrypt_gxl --bl3enc --input ${BL33} --output ${TMP}/bl33.bin.enc ${BL33_ARGS}
+	${QEMU} ./aml_encrypt_gxl --bl3enc --input ${BL33} --output ${TMP}/bl33.bin.enc ${BL33_ARGS}
 
 ${TMP}/bl2.n.bin.sig: ${TMP}/bl2_new.bin
-	./aml_encrypt_gxl --bl2sig --input ${TMP}/bl2_new.bin --output ${TMP}/bl2.n.bin.sig
+	${QEMU} ./aml_encrypt_gxl --bl2sig --input ${TMP}/bl2_new.bin --output ${TMP}/bl2.n.bin.sig
 
 ${O}/u-boot.bin: ${TMP}/bl2.n.bin.sig ${TMP}/bl30_new.bin.enc ${TMP}/bl31.img.enc ${TMP}/bl33.bin.enc
-	./aml_encrypt_gxl --bootmk --output ${O}/u-boot.bin \
+	${QEMU} ./aml_encrypt_gxl --bootmk --output ${O}/u-boot.bin \
 	               --bl2 ${TMP}/bl2.n.bin.sig --bl30 ${TMP}/bl30_new.bin.enc \
 		       --bl31 ${TMP}/bl31.img.enc --bl33 ${TMP}/bl33.bin.enc
 endif

--- a/odroid-c2/Makefile
+++ b/odroid-c2/Makefile
@@ -2,6 +2,11 @@ O ?= .
 TMP ?= .
 BL33 ?=
 
+UNAME_M := $(shell uname -m)
+ifneq ($(UNAME_M),x86_64)
+	QEMU =  qemu-x86_64
+endif
+
 .phony: clean distclean
 
 all: ${O}/u-boot.bin
@@ -15,13 +20,13 @@ distclean: clean
 	rm -f ${O}/u-boot.bin ${O}/u-boot.bin.sd.bin ${O}/u-boot.bin.usb.bl2 ${O}/u-boot.bin.usb.tpl
 
 ${TMP}/fip.bin: bl30.bin bl301.bin bl31.bin ${BL33}
-	./fip_create --bl30 bl30.bin --bl301 bl301.bin --bl31 bl31.bin --bl33 ${BL33} ${TMP}/fip.bin
+	${QEMU} ./fip_create --bl30 bl30.bin --bl301 bl301.bin --bl31 bl31.bin --bl33 ${BL33} ${TMP}/fip.bin
 
 ${TMP}/boot_new.bin: ${TMP}/fip.bin bl2.package
 	cat bl2.package ${TMP}/fip.bin > ${TMP}/boot_new.bin
 
 ${O}/u-boot.bin: ${TMP}/boot_new.bin
-	./aml_encrypt_gxb --bootsig --input ${TMP}/boot_new.bin --output ${O}/u-boot.bin
+	${QEMU} ./aml_encrypt_gxb --bootsig --input ${TMP}/boot_new.bin --output ${O}/u-boot.bin
 	dd if=${O}/u-boot.bin of=${TMP}/u-boot.gxbb bs=512 skip=96
 	dd if=bl1.bin.hardkernel of=${O}/u-boot.bin.sd.bin conv=fsync,notrunc bs=1 count=442
 	dd if=bl1.bin.hardkernel of=${O}/u-boot.bin.sd.bin conv=fsync,notrunc bs=512 skip=1 seek=1


### PR DESCRIPTION
The fip package uses x86_64 binaries to generate the fip. Use qemu-x86_64 when not on an X86 build host.
Build tested `PROJECT=Amlogic ARCH=arm DEVICE=AMLGX make image` successfully on **Ampere A1**